### PR TITLE
Fix the input type check

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 module.exports = object => {
-	if (typeof object !== 'object') {
+	if (typeof object !== 'object' || object === null) {
 		throw new TypeError('Expected an object');
 	}
 

--- a/test.js
+++ b/test.js
@@ -1,6 +1,13 @@
 import test from 'ava';
 import invertKeyValue from '.';
 
+test('throws an error if wrong type is given', t => {
+	const error = t.throws(() => {
+		invertKeyValue(null);
+	}, {instanceOf: TypeError});
+	t.is(error.message, 'Expected an object');
+});
+
 test('inverts string/number properties', t => {
 	t.deepEqual(
 		invertKeyValue({foo: 'bar', unicorn: 'rainbow', 1: 'one'}),

--- a/test.js
+++ b/test.js
@@ -3,8 +3,13 @@ import invertKeyValue from '.';
 
 test('throws an error if wrong type is given', t => {
 	t.throws(
-		() => invertKeyValue(null),
-		{instanceOf: TypeError, message: 'Expected an object'}
+		() => {
+			invertKeyValue(null);
+		},
+		{
+			instanceOf: TypeError,
+			message: 'Expected an object'
+		}
 	);
 });
 

--- a/test.js
+++ b/test.js
@@ -2,10 +2,10 @@ import test from 'ava';
 import invertKeyValue from '.';
 
 test('throws an error if wrong type is given', t => {
-	const error = t.throws(() => {
-		invertKeyValue(null);
-	}, {instanceOf: TypeError});
-	t.is(error.message, 'Expected an object');
+	t.throws(
+		() => invertKeyValue(null),
+		{instanceOf: TypeError, message: 'Expected an object'}
+	);
 });
 
 test('inverts string/number properties', t => {


### PR DESCRIPTION
At the moment, if this function receives `null` as a parameter, it will fail to throw the appropriate error.

This PR adds a check for `null` as a possible and improves testing, taking this into account.