### PR TITLE
Implement stronger mapped TypeScript type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,8 +10,7 @@ invertKeyValue({foo: 'bar', '🦄': '🌈'});
 ```
 */
 export default function invertKeyValue<
-	KeyType extends PropertyKey,
-	ValueType extends PropertyKey
+	T extends Record<PropertyKey, PropertyKey>
 >(
-	object: {[key in KeyType]: ValueType}
-): {[key in ValueType]: KeyType extends number ? Exclude<KeyType, number> | string : KeyType};
+	object: T
+): {[P in keyof T as T[P]]: keyof T extends number ? Exclude<keyof T, number> | string : P};


### PR DESCRIPTION
Making use of 'keyof' and 'as' keywords, it's possible to make typization much stronger, even allowing to invert the object again and again without losing any types.

Before:
> Calling non-existent keys should have failed, but works ok due to the lack of typization.
<img width="343" alt="old" src="https://user-images.githubusercontent.com/46137336/155819877-82602628-53b8-4e88-a4b5-32315d6576e7.png">

After:
> Wow, how is that possible. The type checking has... unfolded in all its power.
<img width="343" alt="new" src="https://user-images.githubusercontent.com/46137336/155820017-1f26e2c8-afa1-4ac8-a005-bd72257913bc.png">

The solution is based on this StackOverflow thread: https://stackoverflow.com/a/56416192/11474669